### PR TITLE
Add option to save RAM.

### DIFF
--- a/localTensoRF/opt.py
+++ b/localTensoRF/opt.py
@@ -167,6 +167,12 @@ def config_parser(cmd=None):
     parser.add_argument("--render_path", type=int, default=1)
     parser.add_argument("--render_from_file", type=str, default="")
 
+    ## ------ For saving RAM ------ ##
+    # Set these flags to save your RAM. The final rendered images are still generated and saved.
+    parser.add_argument("--skip_saving_video", action='store_false', help="If set, will not generate rendered video") # default True if not set, will be False if set.
+    parser.add_argument("--skip_TB_images", action='store_false', help="If set, TensorBoard will not show the rendered images.") # default True if not set, will be False if set.
+
+
     # rendering options
     parser.add_argument("--fea2denseAct", type=str, default="softplus")
     parser.add_argument(

--- a/localTensoRF/opt.py
+++ b/localTensoRF/opt.py
@@ -169,8 +169,8 @@ def config_parser(cmd=None):
 
     ## ------ For saving RAM ------ ##
     # Set these flags to save your RAM. The final rendered images are still generated and saved.
-    parser.add_argument("--skip_saving_video", action='store_false', help="If set, will not generate rendered video") # default True if not set, will be False if set.
-    parser.add_argument("--skip_TB_images", action='store_false', help="If set, TensorBoard will not show the rendered images.") # default True if not set, will be False if set.
+    parser.add_argument("--skip_saving_video", action='store_true', help="If set, will not generate rendered video") # default False if not set, will be True if set.
+    parser.add_argument("--skip_TB_images", action='store_true', help="If set, TensorBoard will not show the rendered images.") # default False if not set, will be True if set.
 
 
     # rendering options

--- a/localTensoRF/train.py
+++ b/localTensoRF/train.py
@@ -548,7 +548,7 @@ def reconstruction(args):
                 test=True,
                 train_dataset=train_dataset,
                 start=train_dataset.active_frames_bounds[0],
-                add_frame_to_list=args.skip_TB_images,
+                add_frame_to_list=args.skip_TB_images, # default True if not set, will be False if set. 
             )
 
             if len(loc_metrics.values()):
@@ -574,7 +574,7 @@ def reconstruction(args):
                     global_step=iteration
                 )
 
-                if args.skip_TB_images:
+                if args.skip_TB_images: # default True if not set, will be False if set.
                     writer.add_images(
                         "test/rgb_maps",
                         torch.stack(rgb_maps_tb, 0),
@@ -616,6 +616,10 @@ def reconstruction(args):
                             global_step=iteration,
                             dataformats="NHWC",
                         )
+
+                    # Clear all TensorBoard's lists
+                    for list_tb in [rgb_maps_tb, depth_maps_tb, gt_rgbs_tb, fwd_flow_cmp_tb, bwd_flow_cmp_tb, depth_err_tb]:
+                        list_tb.clear()
 
             with open(f"{logfolder}/checkpoints_tmp.th", "wb") as f:
                 local_tensorfs.save(f)

--- a/localTensoRF/train.py
+++ b/localTensoRF/train.py
@@ -102,7 +102,7 @@ def render_frames(
             train_dataset=train_dataset,
             img_format="jpg",
             save_frames=True,
-            save_video=args.skip_saving_video,
+            save_video=not args.skip_saving_video, # skip_saving_video=True if set; save_video=False to save RAM --> not args.skip_saving_video
             add_frame_to_list=False,
             floater_thresh=0.5,
         )
@@ -125,7 +125,7 @@ def render_frames(
             train_dataset=train_dataset,
             img_format="jpg",
             save_frames=True,
-            save_video=args.skip_saving_video,
+            save_video=not args.skip_saving_video, # skip_saving_video=True if set; save_video=False to save RAM --> not args.skip_saving_video
             add_frame_to_list=False,
             floater_thresh=0.5,
         )
@@ -548,7 +548,7 @@ def reconstruction(args):
                 test=True,
                 train_dataset=train_dataset,
                 start=train_dataset.active_frames_bounds[0],
-                add_frame_to_list=args.skip_TB_images, # default True if not set, will be False if set. 
+                add_frame_to_list= not args.skip_TB_images, # skip_TB_images=True if set; add_frame_to_list=False to save RAM --> not args.skip_TB_images
             )
 
             if len(loc_metrics.values()):
@@ -574,7 +574,7 @@ def reconstruction(args):
                     global_step=iteration
                 )
 
-                if args.skip_TB_images: # default True if not set, will be False if set.
+                if not args.skip_TB_images: # default False if not set, will be True if set. 
                     writer.add_images(
                         "test/rgb_maps",
                         torch.stack(rgb_maps_tb, 0),

--- a/localTensoRF/train.py
+++ b/localTensoRF/train.py
@@ -80,6 +80,8 @@ def render_frames(
             W=W, H=H,
             savePath=f"{logfolder}/test",
             save_frames=True,
+            save_video=False,
+            add_frame_to_list=False,
             test=True,
             train_dataset=train_dataset,
             img_format="png",
@@ -100,7 +102,8 @@ def render_frames(
             train_dataset=train_dataset,
             img_format="jpg",
             save_frames=True,
-            save_video=True,
+            save_video=args.skip_saving_video,
+            add_frame_to_list=False,
             floater_thresh=0.5,
         )
 
@@ -122,7 +125,8 @@ def render_frames(
             train_dataset=train_dataset,
             img_format="jpg",
             save_frames=True,
-            save_video=True,
+            save_video=args.skip_saving_video,
+            add_frame_to_list=False,
             floater_thresh=0.5,
         )
 
@@ -544,6 +548,7 @@ def reconstruction(args):
                 test=True,
                 train_dataset=train_dataset,
                 start=train_dataset.active_frames_bounds[0],
+                add_frame_to_list=args.skip_TB_images,
             )
 
             if len(loc_metrics.values()):
@@ -569,47 +574,48 @@ def reconstruction(args):
                     global_step=iteration
                 )
 
-                writer.add_images(
-                    "test/rgb_maps",
-                    torch.stack(rgb_maps_tb, 0),
-                    global_step=iteration,
-                    dataformats="NHWC",
-                )
-                writer.add_images(
-                    "test/depth_map",
-                    torch.stack(depth_maps_tb, 0),
-                    global_step=iteration,
-                    dataformats="NHWC",
-                )
-                writer.add_images(
-                    "test/gt_maps",
-                    torch.stack(gt_rgbs_tb, 0),
-                    global_step=iteration,
-                    dataformats="NHWC",
-                )
-                
-                if len(fwd_flow_cmp_tb) > 0:
+                if args.skip_TB_images:
                     writer.add_images(
-                        "test/fwd_flow_cmp",
-                        torch.stack(fwd_flow_cmp_tb, 0)[..., None],
+                        "test/rgb_maps",
+                        torch.stack(rgb_maps_tb, 0),
+                        global_step=iteration,
+                        dataformats="NHWC",
+                    )
+                    writer.add_images(
+                        "test/depth_map",
+                        torch.stack(depth_maps_tb, 0),
+                        global_step=iteration,
+                        dataformats="NHWC",
+                    )
+                    writer.add_images(
+                        "test/gt_maps",
+                        torch.stack(gt_rgbs_tb, 0),
                         global_step=iteration,
                         dataformats="NHWC",
                     )
                     
-                    writer.add_images(
-                        "test/bwd_flow_cmp",
-                        torch.stack(bwd_flow_cmp_tb, 0)[..., None],
-                        global_step=iteration,
-                        dataformats="NHWC",
-                    )
-                
-                if len(depth_err_tb) > 0:
-                    writer.add_images(
-                        "test/depth_cmp",
-                        torch.stack(depth_err_tb, 0)[..., None],
-                        global_step=iteration,
-                        dataformats="NHWC",
-                    )
+                    if len(fwd_flow_cmp_tb) > 0:
+                        writer.add_images(
+                            "test/fwd_flow_cmp",
+                            torch.stack(fwd_flow_cmp_tb, 0)[..., None],
+                            global_step=iteration,
+                            dataformats="NHWC",
+                        )
+                        
+                        writer.add_images(
+                            "test/bwd_flow_cmp",
+                            torch.stack(bwd_flow_cmp_tb, 0)[..., None],
+                            global_step=iteration,
+                            dataformats="NHWC",
+                        )
+                    
+                    if len(depth_err_tb) > 0:
+                        writer.add_images(
+                            "test/depth_cmp",
+                            torch.stack(depth_err_tb, 0)[..., None],
+                            global_step=iteration,
+                            dataformats="NHWC",
+                        )
 
             with open(f"{logfolder}/checkpoints_tmp.th", "wb") as f:
                 local_tensorfs.save(f)


### PR DESCRIPTION
Added two flags for training LocalRF to get the camera poses only.
These flags help reduce the RAM occupation. 

- `skip_saving_video`: If set, will not generate rendered video
- `skip_TB_images`: If set, TensorBoard will not show the rendered images.